### PR TITLE
feat: add compliance dashboard

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -8,6 +8,7 @@ import Feedback360 from '../pages/Feedback360.jsx';
 import Appraisals from '../pages/Appraisals.jsx';
 import Development from '../pages/Development.jsx';
 import Privacy from '../pages/Privacy.jsx';
+import Compliance from '../pages/Compliance.jsx';
 
 const App = () => (
   <BrowserRouter>
@@ -21,6 +22,7 @@ const App = () => (
         <Route path="feedback" element={<Feedback />} />
         <Route path="feedback360" element={<Feedback360 />} />
         <Route path="appraisals" element={<Appraisals />} />
+        <Route path="compliance" element={<Compliance />} />
       </Route>
     </Routes>
   </BrowserRouter>

--- a/src/app/Layout.jsx
+++ b/src/app/Layout.jsx
@@ -31,6 +31,9 @@ const Layout = () => {
           <NavLink to="/feedback" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>{t('feedback')}</NavLink>
           <NavLink to="/feedback360" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>{t('feedback360')}</NavLink>
           <NavLink to="/appraisals" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>{t('appraisals')}</NavLink>
+          {user.role === 'hr' && (
+            <NavLink to="/compliance" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>{t('compliance')}</NavLink>
+          )}
         </nav>
       </div>
       <div className="content flex-grow-1">

--- a/src/pages/Compliance.jsx
+++ b/src/pages/Compliance.jsx
@@ -1,0 +1,76 @@
+import { useContext, useState, useEffect } from 'react';
+import { LanguageContext } from '../context/LanguageContext.jsx';
+import { toast } from 'react-toastify';
+
+const Compliance = () => {
+  const { t } = useContext(LanguageContext);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setLoading(false), 500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const metrics = [
+    { label: t('pfmaAlignment'), value: '90%' },
+    { label: t('sdlTrainingHours'), value: '120/150' },
+    { label: t('popiaAuditStatus'), value: t('compliant') },
+  ];
+
+  const logs = [
+    { user: 'Alice', action: 'Goal Approved', timestamp: '2024-04-01 10:00' },
+    { user: 'Bob', action: 'Report Generated', timestamp: '2024-04-02 12:30' },
+    { user: 'Cara', action: 'Policy Updated', timestamp: '2024-04-03 09:15' },
+    { user: 'Dan', action: 'Goal Rejected', timestamp: '2024-04-03 11:45' },
+    { user: 'Eve', action: 'Goal Approved', timestamp: '2024-04-04 14:20' },
+  ];
+
+  const generateReport = () => {
+    console.log('generate compliance report', { metrics });
+    toast.success(t('reportGenerated'), { className: 'bg-primary text-white' });
+  };
+
+  if (loading) {
+    return <div className="text-center" aria-busy="true" aria-live="polite">Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h2 className="mb-4">{t('compliance')}</h2>
+      <div className="row row-cols-1 row-cols-md-3 g-4 mb-4" aria-label={t('compliance')}>
+        {metrics.map((m) => (
+          <div className="col" key={m.label}>
+            <div className="card text-center" tabIndex="0" aria-label={`${m.label}: ${m.value}`}>
+              <div className="card-body">
+                <h5 className="card-title">{m.label}</h5>
+                <p className="card-text">{m.value}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <h3>{t('auditLog')}</h3>
+      <table className="table" aria-label={t('auditLog')}>
+        <thead>
+          <tr>
+            <th scope="col">{t('user')}</th>
+            <th scope="col">{t('action')}</th>
+            <th scope="col">{t('timestamp')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((log, idx) => (
+            <tr key={idx}>
+              <td>{log.user}</td>
+              <td>{log.action}</td>
+              <td>{log.timestamp}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button className="btn btn-primary" onClick={generateReport}>{t('generateReport')}</button>
+    </div>
+  );
+};
+
+export default Compliance;

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -60,26 +60,33 @@ const ManagerDashboard = () => (
   </div>
 );
 
-const HRDashboard = () => (
-  <div className="row">
-    <div className="col-md-4">
-      <div className="card text-center mb-3">
-        <div className="card-body">
-          <h5 className="card-title">Avg Score</h5>
-          <p className="card-text">4.2</p>
+const HRDashboard = () => {
+  const { t } = useContext(LanguageContext);
+  return (
+    <div className="row">
+      <div className="col-md-4">
+        <div className="card text-center mb-3">
+          <div className="card-body">
+            <h5 className="card-title">Avg Score</h5>
+            <p className="card-text">4.2</p>
+          </div>
+        </div>
+      </div>
+      <div className="col-md-4">
+        <div className="card text-center mb-3">
+          <div className="card-body">
+            <h5 className="card-title">{t('compliance')}</h5>
+            <p className="card-text">
+              {t('pfmaAlignment')}: 90%<br />
+              {t('sdlTrainingHours')}: 120/150<br />
+              {t('popiaAuditStatus')}: {t('compliant')}
+            </p>
+          </div>
         </div>
       </div>
     </div>
-    <div className="col-md-4">
-      <div className="card text-center mb-3">
-        <div className="card-body">
-          <h5 className="card-title">Compliance</h5>
-          <p className="card-text">95%</p>
-        </div>
-      </div>
-    </div>
-  </div>
-);
+  );
+};
 
 const Dashboard = () => {
   const { user } = useContext(UserContext);

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -30,7 +30,18 @@ const translations = {
     save: 'Save',
     planSaved: 'Plan saved',
     plans: 'Plans',
-    avgCompletion: 'Avg Completion'
+    avgCompletion: 'Avg Completion',
+    compliance: 'Compliance',
+    pfmaAlignment: 'PFMA Alignment',
+    sdlTrainingHours: 'SDL Training Hours',
+    popiaAuditStatus: 'POPIA Audit Status',
+    auditLog: 'Audit Log',
+    user: 'User',
+    action: 'Action',
+    timestamp: 'Timestamp',
+    generateReport: 'Generate Compliance Report',
+    reportGenerated: 'Compliance report generated',
+    compliant: 'Compliant'
   },
   af: {
     login: 'Teken In',
@@ -63,7 +74,18 @@ const translations = {
     save: 'Stoor',
     planSaved: 'Plan gestoor',
     plans: 'Planne',
-    avgCompletion: 'Gem Voltooiing'
+    avgCompletion: 'Gem Voltooiing',
+    compliance: 'Nakoming',
+    pfmaAlignment: 'PFMA-belyning',
+    sdlTrainingHours: 'SDL-opleidingsure',
+    popiaAuditStatus: 'POPIA-ouditstatus',
+    auditLog: 'Ouditlog',
+    user: 'Gebruiker',
+    action: 'Aksie',
+    timestamp: 'Tydstempel',
+    generateReport: 'Genereer Nakomingsverslag',
+    reportGenerated: 'Nakomingsverslag gegenereer',
+    compliant: 'In ooreenstemming'
   },
   zu: {
     login: 'Ngena',
@@ -96,7 +118,18 @@ const translations = {
     save: 'Gcina',
     planSaved: 'Uhlelo lugcinwe',
     plans: 'Izinhlelo',
-    avgCompletion: 'Isilinganiso sokuqedwa'
+    avgCompletion: 'Isilinganiso sokuqedwa',
+    compliance: 'Ukuhambisana',
+    pfmaAlignment: 'Ukuvumelana kwe-PFMA',
+    sdlTrainingHours: 'Amahora Oqeqesho e-SDL',
+    popiaAuditStatus: 'Isimo soHlolo se-POPIA',
+    auditLog: 'Ilog ye-Audit',
+    user: 'Umsebenzisi',
+    action: 'Isenzo',
+    timestamp: 'Isikhathi',
+    generateReport: 'Dala umbiko wokuhambisana',
+    reportGenerated: 'Umbiko wokuhambisana ukhiqiziwe',
+    compliant: 'Iyahambisana'
   },
   xh: {
     login: 'Ngena',
@@ -129,7 +162,18 @@ const translations = {
     save: 'Gcina',
     planSaved: 'Isicwangciso sigciniwe',
     plans: 'Izicwangciso',
-    avgCompletion: 'Umyinge wogqibeko'
+    avgCompletion: 'Umyinge wogqibeko',
+    compliance: 'Ukuthotyelwa',
+    pfmaAlignment: 'Ukunyenyiswa kwe-PFMA',
+    sdlTrainingHours: 'Iiyure zoQeqesho ze-SDL',
+    popiaAuditStatus: 'Imeko yoHlolo lwe-POPIA',
+    auditLog: 'Ilog yoHlolo',
+    user: 'Umsebenzisi',
+    action: 'Intshukumo',
+    timestamp: 'Ixesha',
+    generateReport: 'Yenza ingxelo yokuthotyelwa',
+    reportGenerated: 'Ingxelo yokuthotyelwa yenziwe',
+    compliant: 'Iyathobela'
   }
 };
 


### PR DESCRIPTION
## Summary
- add HR compliance page with metrics, audit logs and report generation
- link compliance view in sidebar and routing
- enhance HR dashboard with compliance summary widget and translations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689b0cf74210832da84d3b199514a297